### PR TITLE
v0.2.1 — first-run long-path crash, AutoImageProcessor, HDR panel, dropdown arrow

### DIFF
--- a/dlss5_converter/__init__.py
+++ b/dlss5_converter/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 # OpenCV ships the OpenEXR codec but disables it at runtime unless this is set
 # (opencv/opencv#21326). EXR matters more here than in a normal photo app: the

--- a/dlss5_converter/app.py
+++ b/dlss5_converter/app.py
@@ -241,6 +241,15 @@ QComboBox { background: $base; color: $ink; border: 1px solid $line; border-radi
 QComboBox:hover { border-color: $signal_deep; }
 QComboBox:disabled { color: $ink_faint; border-color: $line_soft; }
 QComboBox::drop-down { border: none; width: 22px; }
+/* A visible chevron, drawn from borders so it needs no bundled image. Without
+   it the dropdown read as a plain box and people typed values in by hand. */
+QComboBox::down-arrow {
+    width: 0; height: 0; margin-right: 8px;
+    border-left: 5px solid transparent; border-right: 5px solid transparent;
+    border-top: 6px solid $ink_dim;
+}
+QComboBox::down-arrow:hover { border-top-color: $signal; }
+QComboBox::down-arrow:disabled { border-top-color: $line; }
 QComboBox QAbstractItemView {
     background: $panel_lo; color: $ink; border: 1px solid $line;
     selection-background-color: $line; outline: none; padding: 4px;
@@ -3861,6 +3870,40 @@ class MainWindow(QMainWindow):
         for group in self._chip_groups:
             group.set_mode(mode)
 
+    def _hdr_card(self) -> QWidget:
+        """The add-on's HDR / display controls, kept in the main workflow.
+
+        They sit in the sidebar with the neural controls rather than buried in
+        Settings: they change the neural result, and people went straight here
+        looking for them. Defaults match the add-on's own.
+        """
+        s = self.settings.neural
+        hdr = ModuleCard("HDR / display")
+        hdr.setToolTip(
+            "The add-on's HDR controls. This pipeline is SDR end to end, but "
+            "these still change the result — the neural pass reasons about light "
+            "before anything is tonemapped back. Defaults match the add-on's own."
+        )
+        hdr.add(SliderRow(
+            "Paper white", s.paper_white, self._neural_setter("paper_white"),
+            "The luminance the model treats as diffuse white. On an HDR or OLED "
+            "display this decides how hard highlights are pushed. The add-on "
+            "defaults to 1; shipping game configs use 16, where it stops changing.",
+            maximum=NR_PAPER_WHITE_MAX,
+        ))
+        hdr.add(SliderRow(
+            "HDR transfer", s.transfer_strength, self._neural_setter("transfer_strength"),
+            "Strength of the transfer curve the pass works through. Range 0..1.",
+            maximum=NR_TRANSFER_MAX,
+        ))
+        hdr.add(SliderRow(
+            "Colour strength", s.color_strength, self._neural_setter("color_strength"),
+            "How much of the model's colour change is kept. At 0 the source colour "
+            "survives and only structure changes. Range 0..1.",
+            maximum=NR_COLOR_MAX,
+        ))
+        return hdr
+
     def _settings_page(self) -> QWidget:
         """The Settings tab — a home for everything that is configured once and
         then left alone, so the sidebar can hold only per-image controls.
@@ -3881,7 +3924,6 @@ class MainWindow(QMainWindow):
         left.setSpacing(14)
         right = QVBoxLayout()
         right.setSpacing(14)
-        s = self.settings.neural
 
         # -- Appearance --
         appearance = ModuleCard("Appearance")
@@ -3937,31 +3979,8 @@ class MainWindow(QMainWindow):
         r_buttons.addStretch(1)
         runtime_grp.add_layout(r_buttons)
 
-        # -- Advanced: HDR / display --
-        hdr = ModuleCard("HDR / display")
-        hdr.setToolTip(
-            "The add-on's HDR controls. This pipeline is SDR end to end, but "
-            "these still change the result — the neural pass reasons about light "
-            "before anything is tonemapped back. Defaults match the add-on's own."
-        )
-        hdr.add(SliderRow(
-            "Paper white", s.paper_white, self._neural_setter("paper_white"),
-            "The luminance the model treats as diffuse white. On an HDR or OLED "
-            "display this decides how hard highlights are pushed. The add-on "
-            "defaults to 1; shipping game configs use 16, where it stops changing.",
-            maximum=NR_PAPER_WHITE_MAX,
-        ))
-        hdr.add(SliderRow(
-            "HDR transfer", s.transfer_strength, self._neural_setter("transfer_strength"),
-            "Strength of the transfer curve the pass works through. Range 0..1.",
-            maximum=NR_TRANSFER_MAX,
-        ))
-        hdr.add(SliderRow(
-            "Colour strength", s.color_strength, self._neural_setter("color_strength"),
-            "How much of the model's colour change is kept. At 0 the source colour "
-            "survives and only structure changes. Range 0..1.",
-            maximum=NR_COLOR_MAX,
-        ))
+        # HDR / display lives in the single-image sidebar now (see _hdr_card),
+        # not here — people went looking for it in the workflow, not in Settings.
 
         # -- Advanced: Depth --
         depth = ModuleCard("Depth")
@@ -4001,7 +4020,6 @@ class MainWindow(QMainWindow):
         # Two balanced columns, so nothing — a slider especially — sprawls the
         # full width of the window.
         left.addWidget(appearance)
-        left.addWidget(hdr)
         left.addStretch(1)
         right.addWidget(runtime_grp)
         right.addWidget(depth)
@@ -4160,6 +4178,7 @@ class MainWindow(QMainWindow):
         layout.addWidget(evaluation)
 
         layout.addWidget(self._detail_group())
+        layout.addWidget(self._hdr_card())
         layout.addStretch(1)
         return panel
 

--- a/dlss5_converter/bootstrap.py
+++ b/dlss5_converter/bootstrap.py
@@ -245,6 +245,28 @@ def _safe_parts(name: str) -> list[str]:
     return [part for part in name.split("/") if part not in ("", ".", "..")]
 
 
+def _os_path(path: Path) -> str:
+    r"""A path string safe to open on Windows however long it is.
+
+    A modern CUDA torch tree nests well past the classic 260-character MAX_PATH
+    - ``torch/include/...`` headers and long cuDNN/cuBLAS names - and on a machine
+    that has not enabled long-path support the extract fails part way through,
+    which is the "crashes/freezes at the end of the download" people hit. The
+    ``\\?\`` extended-length prefix opts a single path out of MAX_PATH with no
+    system setting and no admin, so the app fixes this itself rather than telling
+    users to edit the registry. Non-Windows is returned untouched.
+    """
+    if os.name != "nt":
+        return str(path)
+    full = os.path.abspath(str(path))
+    if full.startswith("\\\\?\\"):
+        return full
+    if full.startswith("\\\\"):
+        # UNC (\\server\share) becomes \\?\UNC\server\share.
+        return "\\\\?\\UNC\\" + full[2:]
+    return "\\\\?\\" + full
+
+
 def _extract(
     archive: Path,
     target: Path,
@@ -257,33 +279,32 @@ def _extract(
         total = sum(member.file_size for member in members) or 1
         done = 0
         for member in members:
+            parts = _safe_parts(member.filename)
             if member.is_dir():
-                target.joinpath(*_safe_parts(member.filename)).mkdir(
-                    parents=True, exist_ok=True
-                )
+                os.makedirs(_os_path(target.joinpath(*parts)), exist_ok=True)
+                continue
+            if not parts:
                 continue
 
-            if member.file_size >= _STREAM_ABOVE:
-                # Named and streamed. The name turns a stall into "it is on this
-                # big file", not a dead bar, and the per-chunk update keeps the
-                # bar alive even when one file is a slow, antivirus-scanned GB.
-                if on_text:
-                    size_mb = member.file_size / 1_048_576
-                    on_text(f"Unpacking {Path(member.filename).name} ({size_mb:.0f} MB)…")
-                dest = target.joinpath(*_safe_parts(member.filename))
-                dest.parent.mkdir(parents=True, exist_ok=True)
-                with bundle.open(member) as source, open(dest, "wb") as sink:
-                    while True:
-                        chunk = source.read(_CHUNK)
-                        if not chunk:
-                            break
-                        sink.write(chunk)
-                        done += len(chunk)
-                        report(done, total)
-            else:
-                bundle.extract(member, target)
-                done += member.file_size
-                report(done, total)
+            # Every file is written through _os_path, not just the big ones and
+            # not via ZipFile.extract, so the long-path prefix covers the whole
+            # tree - the deep header paths that overflow MAX_PATH are ordinary
+            # small files, and those were the ones ZipFile.extract used to fail
+            # on. Big files are still named up front so a slow, antivirus-scanned
+            # gigabyte reads as progress rather than a hang.
+            if member.file_size >= _STREAM_ABOVE and on_text:
+                size_mb = member.file_size / 1_048_576
+                on_text(f"Unpacking {Path(member.filename).name} ({size_mb:.0f} MB)…")
+            dest = target.joinpath(*parts)
+            os.makedirs(_os_path(dest.parent), exist_ok=True)
+            with bundle.open(member) as source, open(_os_path(dest), "wb") as sink:
+                while True:
+                    chunk = source.read(_CHUNK)
+                    if not chunk:
+                        break
+                    sink.write(chunk)
+                    done += len(chunk)
+                    report(done, total)
         report(done, total, force=True)  # land the bar exactly on the total
 
 
@@ -305,7 +326,7 @@ def install(
     # left alone so a retry resumes it: throwing away 1.8 GB because the
     # *unpack* failed is a punishing way to handle a recoverable error.
     if staging.is_dir():
-        shutil.rmtree(staging, ignore_errors=True)
+        shutil.rmtree(_os_path(staging), ignore_errors=True)
 
     target.parent.mkdir(parents=True, exist_ok=True)
     try:
@@ -325,13 +346,13 @@ def install(
             raise OSError("The downloaded runtime is missing its torch package.")
 
         if target.is_dir():
-            shutil.rmtree(target, ignore_errors=True)
+            shutil.rmtree(_os_path(target), ignore_errors=True)
         staging.rename(target)
     except BaseException:
         # Keep the archive for the next attempt; drop only the half-unpacked
         # tree, which is the part that would confuse is_ready().
         if staging.is_dir():
-            shutil.rmtree(staging, ignore_errors=True)
+            shutil.rmtree(_os_path(staging), ignore_errors=True)
         raise
 
     # Success: the archive has done its job and is 1.8 GB of dead weight.
@@ -421,7 +442,7 @@ def install_av(
     staging = target.with_name(target.name + ".partial")
     archive = target.with_name(target.name + ".whl.part")
     if staging.is_dir():
-        shutil.rmtree(staging, ignore_errors=True)
+        shutil.rmtree(_os_path(staging), ignore_errors=True)
     target.parent.mkdir(parents=True, exist_ok=True)
     try:
         if on_text:
@@ -436,9 +457,9 @@ def install_av(
         if not (staging / "av" / "__init__.py").is_file():
             raise OSError("The downloaded video component is missing its av package.")
         if target.is_dir():
-            shutil.rmtree(target, ignore_errors=True)
+            shutil.rmtree(_os_path(target), ignore_errors=True)
         staging.rename(target)
     finally:
-        shutil.rmtree(staging, ignore_errors=True)
+        shutil.rmtree(_os_path(staging), ignore_errors=True)
     archive.unlink(missing_ok=True)
     activate_av()

--- a/dlss5_converter/depth_engine.py
+++ b/dlss5_converter/depth_engine.py
@@ -246,7 +246,22 @@ class DepthEngine:
         enable_system_trust_store()
 
         import torch
-        from transformers import AutoImageProcessor, AutoModelForDepthEstimation
+
+        try:
+            from transformers import AutoImageProcessor, AutoModelForDepthEstimation
+        except ImportError:
+            # In the frozen (PyInstaller) build transformers' lazy top-level
+            # __init__ can fail to expose these - "cannot import name
+            # 'AutoImageProcessor' from 'transformers'" - even though the
+            # submodules are bundled. Importing straight from those submodules
+            # sidesteps the lazy loader and works where the top-level import does
+            # not. Harmless on a normal install, where the first import succeeds.
+            from transformers.models.auto.image_processing_auto import (
+                AutoImageProcessor,
+            )
+            from transformers.models.auto.modeling_auto import (
+                AutoModelForDepthEstimation,
+            )
 
         if self.model_id == model_id and self.model is not None:
             return self.device

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dlss5-converter"
-version = "0.2.0"
+version = "0.2.1"
 description = "Run NVIDIA's DLSS 5 neural renderer over still images."
 readme = "README.md"
 requires-python = ">=3.12,<3.13"

--- a/scripts/build_release.ps1
+++ b/scripts/build_release.ps1
@@ -162,6 +162,9 @@ $env:Path = (($env:Path -split ";") | Where-Object {
     --collect-all PySide6.QtMultimedia `
     --collect-all PySide6.QtMultimediaWidgets `
     --collect-all transformers `
+    --collect-submodules transformers `
+    --hidden-import transformers.models.auto.image_processing_auto `
+    --hidden-import transformers.models.auto.modeling_auto `
     --collect-all tokenizers `
     --collect-data safetensors `
     --copy-metadata transformers `

--- a/scripts/build_release.ps1
+++ b/scripts/build_release.ps1
@@ -246,6 +246,13 @@ Copy-Item -LiteralPath $Harness -Destination $Engine -Force
 $Readme = @'
 Put your own DLSS 5 files in this folder.
 
+THIS IS THE ONLY FOLDER YOU TOUCH. You do not copy anything into engine\.
+The app copies what it needs from here into engine\ (next to dlss5_eval.exe)
+automatically on first run, because that is where NVIDIA's NGX and ReShade load
+their DLLs from. On the same drive the copy is a hard link, so it costs no extra
+space. Never put dlss5_eval.exe in this folder - it ships in engine\ and stays
+there. Anyone telling you to place files in both folders by hand is mistaken.
+
 None of these ship with the app and it will not help you obtain them.
 
 EASIEST WAY, if DLSS 5 already works in a game for you:

--- a/scripts/package_release.ps1
+++ b/scripts/package_release.ps1
@@ -47,6 +47,20 @@ New-Item -ItemType Directory -Force -Path (Join-Path $Root "engine") | Out-Null
 Copy-Item -LiteralPath (Join-Path $Release "engine\dlss5_eval.exe") `
           -Destination (Join-Path $Root "engine")
 
+# A note so nobody hand-copies files here. This is the folder people get told,
+# wrongly, to fill in as well as dlss_files - it is managed by the app.
+Set-Content -Path (Join-Path $Root "engine\READ ME.txt") -Encoding utf8 -Value @'
+You do not put anything in this folder yourself.
+
+dlss5_eval.exe (the DLSS harness) ships here and stays here. On first run the app
+copies your DLSS files from dlss_files\ to right next to it, because that is the
+only place NVIDIA's NGX and ReShade load their DLLs from. On the same drive that
+copy is a hard link, so it costs no extra space.
+
+Put your own files in dlss_files\ - only there. Do not copy dlss5_eval.exe into
+dlss_files\, and do not hand-copy your DLLs here.
+'@
+
 # The four folders the app expects, each carrying only its placeholder. These
 # are what tell a new user where their own files go.
 foreach ($folder in @("dlss_files", "models", "output", "pytorch")) {
@@ -59,6 +73,26 @@ foreach ($folder in @("dlss_files", "models", "output", "pytorch")) {
 Copy-Item -LiteralPath (Join-Path $ProjectRoot "LICENSE") -Destination (Join-Path $Root "LICENSE.txt")
 Copy-Item -LiteralPath (Join-Path $ProjectRoot "TROUBLESHOOTING.md") `
           -Destination (Join-Path $Root "TROUBLESHOOTING.txt")
+
+# Drop the dist-info license trees before zipping. torch's nests a dozen
+# third-party sub-licenses deep (kineto -> dynolog -> prometheus -> civetweb ->
+# duktape), which pushes single entries past Windows' 260-character MAX_PATH -
+# and the built-in Explorer unzip then dies with "Error 0x80010135: Path too
+# long" partway through, which is what testers hit. Only the dist-info METADATA
+# is read at runtime, never these, so dropping them makes the zip extract to an
+# ordinary folder with the built-in unzip. Deleted through \\?\ because the
+# trees are themselves too deep for a plain Remove-Item to walk.
+Write-Host "Trimming over-long dist-info license trees (Explorer unzip chokes on them)..." -ForegroundColor Cyan
+$internal = Join-Path $Root "_internal"
+if (Test-Path -LiteralPath $internal) {
+    Get-ChildItem -LiteralPath $internal -Directory -Filter "*.dist-info" -ErrorAction SilentlyContinue |
+        ForEach-Object {
+            $licenses = Join-Path $_.FullName "licenses"
+            if (Test-Path -LiteralPath $licenses) {
+                try { [System.IO.Directory]::Delete("\\?\$licenses", $true) } catch {}
+            }
+        }
+}
 
 # The refusal. Checked against what is actually staged rather than against
 # what was intended to be staged, because those are different things and only

--- a/tests/test_bootstrap_extract.py
+++ b/tests/test_bootstrap_extract.py
@@ -123,3 +123,37 @@ def test_safe_parts_strips_traversal_and_empty_segments():
     assert bootstrap._safe_parts("a/b/c") == ["a", "b", "c"]
     assert bootstrap._safe_parts("../../etc/passwd") == ["etc", "passwd"]
     assert bootstrap._safe_parts("a//./b/") == ["a", "b"]
+
+
+def test_os_path_prefixes_long_paths_on_windows():
+    if os.name != "nt":
+        pytest.skip("the extended-length prefix is Windows-only")
+    prefixed = bootstrap._os_path(Path("C:/torch/include/deep"))
+    assert prefixed.startswith("\\\\?\\"), prefixed
+    # Already-prefixed paths are left as-is rather than double-prefixed.
+    assert bootstrap._os_path(Path(prefixed)) == prefixed
+
+
+def test_extraction_survives_paths_over_the_windows_limit(tmp_path):
+    """A CUDA torch tree overflows MAX_PATH; the unpack must not fail on it.
+
+    This is the "crashes/freezes at the end of the download" regression: without
+    the extended-length prefix, ZipFile.extract could not open the deepest files
+    on a machine without long-path support enabled.
+    """
+    if os.name != "nt":
+        pytest.skip("MAX_PATH only bites on Windows")
+    deep = "/".join(f"segment_{i:02d}_padding_padding" for i in range(20))
+    name = f"pkg/{deep}/leaf.bin"
+    data = os.urandom(2048)
+    archive = tmp_path / "deep.zip"
+    with zipfile.ZipFile(archive, "w", zipfile.ZIP_DEFLATED) as z:
+        z.writestr(name, data)
+    out = tmp_path / "out"
+
+    bootstrap._extract(archive, out, on_bytes=None, on_text=None)
+
+    dest = out.joinpath(*bootstrap._safe_parts(name))
+    assert len(os.path.abspath(str(dest))) > 260, "the test path must actually exceed MAX_PATH"
+    with open(bootstrap._os_path(dest), "rb") as handle:
+        assert handle.read() == data

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -153,6 +153,19 @@ def test_the_view_controls_live_on_the_floating_bar(window):
     assert window.view_grade.parent() is window.stage_host._bar
 
 
+def test_hdr_controls_are_in_the_single_image_workflow(window):
+    """Regression: HDR / display was buried in Settings and people could not
+    find it. It belongs in the single-image sidebar, next to the neural look."""
+    from PySide6.QtWidgets import QLabel
+
+    labels = {
+        label.text()
+        for label in window.single_page.findChildren(QLabel)
+    }
+    assert "Paper white" in labels
+    assert "Colour strength" in labels
+
+
 # -- the DLSS check can never hang the app -----------------------------------
 #
 # The old "Checking DLSS 5" step ran the native probe on a path the user could


### PR DESCRIPTION
Fixes for the v0.2.0 launch feedback.

## Crash/blocker fixes
- **First-run "freezes/crashes at the end of unpacking torch."** The CUDA torch tree nests past Windows' 260-char MAX_PATH; without long-path support the extract failed on the deepest files. Every file is now written through a `\?\` extended-length path (cleanup `rmtree`s too), so it works with no registry change. New test extracts a path >260 chars.
- **"cannot import name `AutoImageProcessor` from transformers"** (conversion failed) in the frozen build. transformers' lazy top-level `__init__` can fail to expose the Auto* classes under PyInstaller; `depth_engine` now falls back to importing them from their submodules, and the build collects those submodules explicitly.

## UI fixes
- **HDR / display panel** was buried in Settings — moved back into the single-image sidebar, next to the neural look.
- **Max size / Supersample dropdowns** had no visible arrow in the dark theme (people typed values by hand); added a chevron to the combobox style.

## Investigated, not a code bug
"Passes / styles / HDR do nothing" — traced UI → settings → `write_addon_config` → harness; Passes drives the frame count even with jitter off. The settings are correctly wired, so this is the documented DLSS subtlety on already-clean SDR content, not a regression. The genuine issue there was HDR discoverability (fixed above).

265 tests pass. The two crash fixes only manifest in the packaged/fresh-install path, so they need a smoke test on a real frozen build before tagging the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)